### PR TITLE
Added Storyboard and Interface Builder support

### DIFF
--- a/Smooth Line View/SmoothLineView.m
+++ b/Smooth Line View/SmoothLineView.m
@@ -24,13 +24,27 @@ CGPoint midPoint(CGPoint p1, CGPoint p2);
 
 #pragma mark -
 
+-(void)setup
+{
+    self.lineWidth = DEFAULT_WIDTH;
+    self.lineColor = DEFAULT_COLOR;
+}
+
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {
         self.backgroundColor = [UIColor whiteColor];
-        self.lineWidth = DEFAULT_WIDTH;
-        self.lineColor = DEFAULT_COLOR;
+        [self setup];
+    }
+    return self;
+}
+
+-(id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self setup];
     }
     return self;
 }


### PR DESCRIPTION
Moved initialization code into a -(void)setup method and called it from both initWithFrame: and initWithCoder: so you can setup a SmoothLineView visually in your storyboard or XIB editor.

The initWithCoder path doesn't set a background color default, since the XIB will already set a backgroundColor property for the view.
