### PR TITLE
Fixing a bug that can cause line breakage with slow finger movements

### DIFF
--- a/Smooth Line View/SmoothLineView.m
+++ b/Smooth Line View/SmoothLineView.m
@@ -135,7 +135,7 @@ CGPoint midPoint(CGPoint p1, CGPoint p2) {
   
   // update points: previousPrevious -> mid1 -> previous -> mid2 -> current
   self.previousPreviousPoint = self.previousPoint;
-  self.previousPoint = [touch previousLocationInView:self];
+  self.previousPoint = self.currentPoint;
   self.currentPoint = [touch locationInView:self];
   
   CGPoint mid1 = midPoint(self.previousPoint, self.previousPreviousPoint);


### PR DESCRIPTION
When finger movement distance is under the minimum set threshold, UITouch is loosing its [touch previousLocationInView] to an unrelated point. This causes the path segments to have a gap.
